### PR TITLE
changing addAllItems to addAllItem to match org.apache.mesos.Protos

### DIFF
--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1335,7 +1335,7 @@
   clojure.lang.PersistentHashSet
   (data->pb [this]
     (-> (Protos$Value$Set/newBuilder)
-        (.addAllItems (seq this))
+        (.addAllItem (seq this))
         (.build)))
   java.lang.String
   (data->pb [this]


### PR DESCRIPTION
Protos$Value$Set$Builder has a method addAllItem. In types.clj it was addAllItems. This changes fixes the mismatch.

org.apache.mesos.Protos.Value.Set.Builder addAllItem(java.lang.Iterable<java.lang.String> values) 
