### PR TITLE
empty set is truthy, should check that it is empty instead

### DIFF
--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -506,7 +506,7 @@
         (cond->
             scalar (.setScalar (data->pb scalar))
             ranges (.setRanges (data->pb (ValueRanges. ranges)))
-            set    (.setSet (data->pb set))
+            (not (empty? set))    (.setSet (data->pb set))
             role   (.setRole role))
         (.build))))
 

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -506,7 +506,7 @@
         (cond->
             scalar (.setScalar (data->pb scalar))
             ranges (.setRanges (data->pb (ValueRanges. ranges)))
-            (not (empty? set))    (.setSet (data->pb set))
+            (seq set)    (.setSet (data->pb set))
             role   (.setRole role))
         (.build))))
 


### PR DESCRIPTION
I think the cond-> in Attribute.data->pb should check that the set is empty because #{} is truthy.
