### PR TITLE
Translates map task ids to pb for TaskStatus

### DIFF
--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1195,7 +1195,7 @@
   Serializable
   (data->pb [this]
     (-> (Protos$TaskStatus/newBuilder)
-        (.setTaskId (data->pb task-id))
+        (.setTaskId (->pb :TaskID task-id))
         (.setState (data->pb state))
         (cond->
             message     (.setMessage (str message))


### PR DESCRIPTION
## Problem

``` clojure
(.reconcile-tasks driver [{:task-id {:value "123"}
                           :state :task-running}])
```

The above code throws an exception because `task-id` is a map instead of a record, but every other driver function supports maps.
## Solution

This change updates `TaskStatus` to support either a record or a map for task id.
