### PR TITLE
TaskInfo seemed to be setting executor with container data.

### DIFF
--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1101,7 +1101,7 @@
           (.setTaskId (->pb :TaskID task-id))
           (.setSlaveId (->pb :SlaveID slave-id))
           (cond->
-              executor     (.setExecutor (->pb :ExecutorInfo container))
+              executor     (.setExecutor (->pb :ExecutorInfo executor))
               command      (.setCommand (->pb :CommandInfo command))
               container    (.setContainer (->pb :ContainerInfo container))
               data         (.setData data)

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -464,7 +464,7 @@
         (.setExecutorId (->pb :ExecutorID executor-id))
         (.setCommand (->pb :CommandInfo command))
         (cond->
-            framework-id (.setFrameWorkId (->pb :FrameworkID framework-id))
+            framework-id (.setFrameworkId (->pb :FrameworkID framework-id))
             container    (.setContainer (->pb :ContainerInfo container))
             name         (.setName (str name))
             source       (.setSource (str source))

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -462,7 +462,7 @@
   (data->pb [this]
     (-> (Protos$ExecutorInfo/newBuilder)
         (.setExecutorId (->pb :ExecutorID executor-id))
-        (.setCommandInfo (->pb :CommandInfo command))
+        (.setCommand (->pb :CommandInfo command))
         (cond->
             framework-id (.setFrameWorkId (->pb :FrameworkID framework-id))
             container    (.setContainer (->pb :ContainerInfo container))


### PR DESCRIPTION
There seem to be some other issues, too (such as typos in method names). I'll update this branch with my fixes -- let me know if you'd like these separated out into different branches.
