### PR TITLE
Address the issue of executor-driver bombing out when passing map data

### DIFF
--- a/async/src/mesomatic/async/scheduler.clj
+++ b/async/src/mesomatic/async/scheduler.clj
@@ -14,7 +14,7 @@
     (reregistered
      [this driver master-info]
      (put! ch {:type        :reregistered
-               :driver      :driver
+               :driver      driver
                :master-info master-info}))
     (disconnected
      [this driver]

--- a/src/mesomatic/executor.clj
+++ b/src/mesomatic/executor.clj
@@ -54,7 +54,7 @@
 
 (defn executor-driver
   [executor]
-  (let [d (MesosExecutorDriver. (->pb :ExecutorInfo executor))]
+  (let [d (MesosExecutorDriver. executor)]
     (reify ExecutorDriver
       (abort! [this]
         (pb->data (.abort d)))

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -362,7 +362,7 @@
    (.getPrincipal info)
    (.getWebuiUrl info)
    (when-let [labels (.getLabels info)] (pb->data labels))
-   (mapv pb->data (.getAllCapabilities info))))
+   (mapv pb->data (.getCapabilitiesList info))))
 
 ;; HealthCheck
 ;; ===========
@@ -1051,7 +1051,7 @@
 
 (defmethod pb->data Protos$Ports
   [^Protos$Ports ports]
-  (Ports. (mapv pb->data (.getAllPorts ports))))
+  (Ports. (mapv pb->data (.getPortsList ports))))
 
 ;; DiscoveryInfo
 ;; =============
@@ -1452,7 +1452,7 @@
 
 (defmethod pb->data Protos$Labels
   [^Protos$Labels labels]
-  (Labels. (mapv pb->data (.getAllLabels labels))))
+  (Labels. (mapv pb->data (.getLabelsList labels))))
 
 
 ;; Safe for the common stuff in extend-protocol, this marks the end of


### PR DESCRIPTION
Mirror the behaviour of the Java library.

This may be a risky change, as other code/projects may depend upon the old
behaviour. (Although I'm not really sure how ... it wasn't usable for me.)

This addresses issue #8, but may need more work (depending upon impact).
