### PR TITLE
`cond` -> `case` where appropriate

### DIFF
--- a/src/mesomatic/allocator.clj
+++ b/src/mesomatic/allocator.clj
@@ -118,11 +118,11 @@
    when appropriate."
   [cpus mem ports]
   (fn [{:keys [name] :as record}]
-    (cond
-      (= name "mem")  (update record :scalar - mem)
-      (= name "cpus") (update record :scalar - cpus)
-      (= name "ports") (update record :ranges adjust-ports ports)
-      :else record)))
+    (case name
+      "mem"   (update record :scalar - mem)
+      "cpus"  (update record :scalar - cpus)
+      "ports" (update record :ranges adjust-ports ports)
+      record)))
 
 (defn adjust-offer
   "If an offer has been accepted, decrease its available resources."

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -97,14 +97,15 @@
 ;; will can be converted back with the extend-protocol
 ;; trick later on.
 
+(def ^:private Protos$Status-dispatch-map
+  {Protos$Status/DRIVER_RUNNING     :driver-running
+   Protos$Status/DRIVER_NOT_STARTED :driver-not-started
+   Protos$Status/DRIVER_ABORTED     :driver-aborted
+   Protos$Status/DRIVER_STOPPED     :driver-stopped})
+
 (defmethod pb->data Protos$Status
   [^Protos$Status status]
-  (case status
-    Protos$Status/DRIVER_RUNNING     :driver-running
-    Protos$Status/DRIVER_NOT_STARTED :driver-not-started
-    Protos$Status/DRIVER_ABORTED     :driver-aborted
-    Protos$Status/DRIVER_STOPPED     :driver-stopped
-    status))
+  (get Protos$Status-dispatch-map status status))
 
 ;; FrameworkID
 ;; ===========
@@ -293,12 +294,14 @@
 ;; MachineInfo
 ;; ===========
 
+(def ^:private Protos$MachineInfo$Mode-dispatch-map
+  {Protos$MachineInfo$Mode/UP       :machine-mode-up
+   Protos$MachineInfo$Mode/DRAINING :machine-mode-draining
+   Protos$MachineInfo$Mode/DOWN     :machine-mode-down})
+
 (defmethod pb->data Protos$MachineInfo$Mode
   [^Protos$MachineInfo$Mode mode]
-  (case mode
-    Protos$MachineInfo$Mode/UP       :machine-mode-up
-    Protos$MachineInfo$Mode/DRAINING :machine-mode-draining
-    Protos$MachineInfo$Mode/DOWN     :machine-mode-down))
+  (get Protos$MachineInfo$Mode-dispatch-map mode))
 
 (defrecord MachineInfo [id mode unavailability]
   Serializable
@@ -332,9 +335,8 @@
 
 (defmethod pb->data Protos$FrameworkInfo$Capability$Type
   [^Protos$FrameworkInfo$Capability$Type type]
-  (case
-    Protos$FrameworkInfo$Capability$Type/REVOCABLE_RESOURCES type
-    :framework-capability-revocable-resource))
+  (cond (= type Protos$FrameworkInfo$Capability$Type/REVOCABLE_RESOURCES)
+        :framework-capability-revocable-resource))
 
 (defrecord FrameworkInfo [user name id failover-timeout checkpoint role
                           hostname principal webui-url capabilities labels]
@@ -550,14 +552,15 @@
 ;; Value
 ;; =====
 
+(def ^:private Protos$Value$Type-dispatch-map
+  {Protos$Value$Type/SCALAR :value-scalar
+   Protos$Value$Type/RANGES :value-ranges
+   Protos$Value$Type/SET    :value-set
+   Protos$Value$Type/TEXT   :value-text})
+
 (defmethod pb->data Protos$Value$Type
   [^Protos$Value$Type type]
-  (case type
-    Protos$Value$Type/SCALAR :value-scalar
-    Protos$Value$Type/RANGES :value-ranges
-    Protos$Value$Type/SET    :value-set
-    Protos$Value$Type/TEXT   :value-text
-    type))
+  (get Protos$Value$Type-dispatch-map type type))
 
 (defmethod pb->data Protos$Value$Scalar
   [^Protos$Value$Scalar scalar]
@@ -1030,15 +1033,16 @@
 ;; Operation
 ;; =========
 
+(def ^:private Protos$Offer$Operation$Type-dispatch-map
+  {Protos$Offer$Operation$Type/LAUNCH    :operation-launch
+   Protos$Offer$Operation$Type/RESERVE   :operation-reserve
+   Protos$Offer$Operation$Type/UNRESERVE :operation-unreserve
+   Protos$Offer$Operation$Type/CREATE    :operation-create
+   Protos$Offer$Operation$Type/DESTROY   :operation-destroy})
+
 (defmethod pb->data Protos$Offer$Operation$Type
   [^Protos$Offer$Operation$Type type]
-  (case type
-    Protos$Offer$Operation$Type/LAUNCH    :operation-launch
-    Protos$Offer$Operation$Type/RESERVE   :operation-reserve
-    Protos$Offer$Operation$Type/UNRESERVE :operation-unreserve
-    Protos$Offer$Operation$Type/CREATE    :operation-create
-    Protos$Offer$Operation$Type/DESTROY   :operation-destroy
-    type))
+  (get Protos$Offer$Operation$Type-dispatch-map type type))
 
 (defrecord Operation [type tasks resources volumes]
   Serializable
@@ -1175,15 +1179,14 @@
                   (when-let [ports (.getPorts di)] (pb->data ports))
                   (when-let [labels (.getLabels di)] (pb->data labels))))
 
+(def ^:private Protos$DiscoveryInfo$Visibility-dispatch-map
+  {Protos$DiscoveryInfo$Visibility/FRAMEWORK :discovery-visibility-framework
+   Protos$DiscoveryInfo$Visibility/CLUSTER   :discovery-visibility-cluster
+   Protos$DiscoveryInfo$Visibility/EXTERNAL  :discovery-visibility-external})
+
 (defmethod pb->data Protos$DiscoveryInfo$Visibility
   [^Protos$DiscoveryInfo$Visibility vis]
-  (case vis
-    Protos$DiscoveryInfo$Visibility/FRAMEWORK
-    :discovery-visibility-framework
-    Protos$DiscoveryInfo$Visibility/CLUSTER
-    :discovery-visibility-cluster
-    Protos$DiscoveryInfo$Visibility/EXTERNAL
-    :discovery-visibility-external))
+  (get Protos$DiscoveryInfo$Visibility-dispatch-map vis))
 
 ;; TaskInfo
 ;; ========
@@ -1223,66 +1226,69 @@
 ;; TaskState
 ;; =========
 
+(def ^:private Protos$TaskState-dispatch-map
+  {Protos$TaskState/TASK_STAGING  :task-staging
+   Protos$TaskState/TASK_STARTING :task-starting
+   Protos$TaskState/TASK_RUNNING  :task-running
+   Protos$TaskState/TASK_FINISHED :task-finished
+   Protos$TaskState/TASK_FAILED   :task-failed
+   Protos$TaskState/TASK_KILLED   :task-killed
+   Protos$TaskState/TASK_LOST     :task-lost
+   Protos$TaskState/TASK_ERROR    :task-error})
+
 (defmethod pb->data Protos$TaskState
   [^Protos$TaskState status]
-  (case status
-    Protos$TaskState/TASK_STAGING  :task-staging
-    Protos$TaskState/TASK_STARTING :task-starting
-    Protos$TaskState/TASK_RUNNING  :task-running
-    Protos$TaskState/TASK_FINISHED :task-finished
-    Protos$TaskState/TASK_FAILED   :task-failed
-    Protos$TaskState/TASK_KILLED   :task-killed
-    Protos$TaskState/TASK_LOST     :task-lost
-    Protos$TaskState/TASK_ERROR    :task-error
-    status))
+  (get Protos$TaskState-dispatch-map status status))
 
 ;; TaskStatus
 ;; ==========
 
+(def ^:private Protos$TaskStatus$Source-dispatch-map
+  {Protos$TaskStatus$Source/SOURCE_MASTER   :source-master
+   Protos$TaskStatus$Source/SOURCE_SLAVE    :source-slave
+   Protos$TaskStatus$Source/SOURCE_EXECUTOR :source-executor})
+
 (defmethod pb->data Protos$TaskStatus$Source
   [^Protos$TaskStatus$Source status]
-  (case status
-    Protos$TaskStatus$Source/SOURCE_MASTER   :source-master
-    Protos$TaskStatus$Source/SOURCE_SLAVE    :source-slave
-    Protos$TaskStatus$Source/SOURCE_EXECUTOR :source-executor
-    status))
+  (get Protos$TaskStatus$Source-dispatch-map status status))
+
+(def ^:private Protos$TaskStatus$Reason-dispatch-map
+  {Protos$TaskStatus$Reason/REASON_COMMAND_EXECUTOR_FAILED
+   :reason-command-executor-failed
+   Protos$TaskStatus$Reason/REASON_EXECUTOR_TERMINATED
+   :reason-executor-terminated
+   Protos$TaskStatus$Reason/REASON_EXECUTOR_UNREGISTERED
+   :reason-executor-unregistered
+   Protos$TaskStatus$Reason/REASON_FRAMEWORK_REMOVED
+   :reason-framework-removed
+   Protos$TaskStatus$Reason/REASON_GC_ERROR
+   :reason-gc-error
+   Protos$TaskStatus$Reason/REASON_INVALID_FRAMEWORKID
+   :reason-invalid-frameworkid
+   Protos$TaskStatus$Reason/REASON_INVALID_OFFERS
+   :reason-invalid-offers
+   Protos$TaskStatus$Reason/REASON_MASTER_DISCONNECTED
+   :reason-master-disconnected
+   Protos$TaskStatus$Reason/REASON_RECONCILIATION
+   :reason-reconciliation
+   Protos$TaskStatus$Reason/REASON_SLAVE_DISCONNECTED
+   :reason-slave-disconnected
+   Protos$TaskStatus$Reason/REASON_SLAVE_REMOVED
+   :reason-slave-removed
+   Protos$TaskStatus$Reason/REASON_SLAVE_RESTARTED
+   :reason-slave-restarted
+   Protos$TaskStatus$Reason/REASON_SLAVE_UNKNOWN
+   :reason-slave-unknown
+   Protos$TaskStatus$Reason/REASON_TASK_INVALID
+   :reason-task-invalid
+   Protos$TaskStatus$Reason/REASON_TASK_UNAUTHORIZED
+   :reason-task-unauthorized
+   Protos$TaskStatus$Reason/REASON_TASK_UNKNOWN
+   :reason-task-unknown})
 
 (defmethod pb->data Protos$TaskStatus$Reason
   [^Protos$TaskStatus$Reason status]
-  (case status
-    Protos$TaskStatus$Reason/REASON_COMMAND_EXECUTOR_FAILED
-    :reason-command-executor-failed
-    Protos$TaskStatus$Reason/REASON_EXECUTOR_TERMINATED
-    :reason-executor-terminated
-    Protos$TaskStatus$Reason/REASON_EXECUTOR_UNREGISTERED
-    :reason-executor-unregistered
-    Protos$TaskStatus$Reason/REASON_FRAMEWORK_REMOVED
-    :reason-framework-removed
-    Protos$TaskStatus$Reason/REASON_GC_ERROR
-    :reason-gc-error
-    Protos$TaskStatus$Reason/REASON_INVALID_FRAMEWORKID
-    :reason-invalid-frameworkid
-    Protos$TaskStatus$Reason/REASON_INVALID_OFFERS
-    :reason-invalid-offers
-    Protos$TaskStatus$Reason/REASON_MASTER_DISCONNECTED
-    :reason-master-disconnected
-    Protos$TaskStatus$Reason/REASON_RECONCILIATION
-    :reason-reconciliation
-    Protos$TaskStatus$Reason/REASON_SLAVE_DISCONNECTED
-    :reason-slave-disconnected
-    Protos$TaskStatus$Reason/REASON_SLAVE_REMOVED
-    :reason-slave-removed
-    Protos$TaskStatus$Reason/REASON_SLAVE_RESTARTED
-    :reason-slave-restarted
-    Protos$TaskStatus$Reason/REASON_SLAVE_UNKNOWN
-    :reason-slave-unknown
-    Protos$TaskStatus$Reason/REASON_TASK_INVALID
-    :reason-task-invalid
-    Protos$TaskStatus$Reason/REASON_TASK_UNAUTHORIZED
-    :reason-task-unauthorized
-    Protos$TaskStatus$Reason/REASON_TASK_UNKNOWN
-    :reason-task-unknown
-    status))
+  (get Protos$TaskStatus$Reason-dispatch-map status status))
 
 (defrecord TaskStatus [task-id state message source reason
                        data slave-id executor-id timestamp
@@ -1450,12 +1456,13 @@
 ;; Volume
 ;; ======
 
+(def ^:private Protos$Volume$Mode-dispatch-map
+  {Protos$Volume$Mode/RW :volume-rw
+   Protos$Volume$Mode/RO :volume-ro})
+
 (defmethod pb->data Protos$Volume$Mode
   [^Protos$Volume$Mode mode]
-  (case mode
-    Protos$Volume$Mode/RW :volume-rw
-    Protos$Volume$Mode/RO :volume-ro
-    mode))
+  (get Protos$Volume$Mode-dispatch-map mode mode))
 
 (defrecord Volume [container-path host-path mode]
   Serializable
@@ -1468,12 +1475,13 @@
 ;; ContainerInfo
 ;; =============
 
+(def ^:private Protos$ContainerInfo$Type-dispatch-map
+  {Protos$ContainerInfo$Type/DOCKER :container-type-docker
+   Protos$ContainerInfo$Type/MESOS  :conatiner-type-mesos})
+
 (defmethod pb->data Protos$ContainerInfo$Type
   [^Protos$ContainerInfo$Type type]
-  (cond type
-    Protos$ContainerInfo$Type/DOCKER :container-type-docker
-    Protos$ContainerInfo$Type/MESOS  :conatiner-type-mesos
-    type))
+  (get Protos$ContainerInfo$Type-dispatch-map type type))
 
 (defrecord PortMapping [host-port container-port protocol]
     Serializable
@@ -1491,16 +1499,17 @@
    (.getContainerPort pm)
    (.getProtocol pm)))
 
+(def ^:private Protos$ContainerInfo$DockerInfo$Network-dispatch-map
+  {Protos$ContainerInfo$DockerInfo$Network/HOST
+   :docker-network-host
+   Protos$ContainerInfo$DockerInfo$Network/BRIDGE
+   :docker-network-bridge
+   Protos$ContainerInfo$DockerInfo$Network/NONE
+   :docker-network-none})
+
 (defmethod pb->data Protos$ContainerInfo$DockerInfo$Network
   [^Protos$ContainerInfo$DockerInfo$Network network]
-  (case network
-    Protos$ContainerInfo$DockerInfo$Network/HOST
-    :docker-network-host
-    Protos$ContainerInfo$DockerInfo$Network/BRIDGE
-    :docker-network-bridge
-    Protos$ContainerInfo$DockerInfo$Network/NONE
-    :docker-network-none
-    network))
+  (get Protos$ContainerInfo$DockerInfo$Network-dispatch-map network network))
 
 (defrecord DockerInfo [image network port-mappings
                        privileged parameters]

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -99,12 +99,12 @@
 
 (defmethod pb->data Protos$Status
   [^Protos$Status status]
-  (cond
-    (= status Protos$Status/DRIVER_RUNNING)     :driver-running
-    (= status Protos$Status/DRIVER_NOT_STARTED) :driver-not-started
-    (= status Protos$Status/DRIVER_ABORTED)     :driver-aborted
-    (= status Protos$Status/DRIVER_STOPPED)     :driver-stopped
-    :else status))
+  (case status
+    Protos$Status/DRIVER_RUNNING     :driver-running
+    Protos$Status/DRIVER_NOT_STARTED :driver-not-started
+    Protos$Status/DRIVER_ABORTED     :driver-aborted
+    Protos$Status/DRIVER_STOPPED     :driver-stopped
+    status))
 
 ;; FrameworkID
 ;; ===========
@@ -295,10 +295,10 @@
 
 (defmethod pb->data Protos$MachineInfo$Mode
   [^Protos$MachineInfo$Mode mode]
-  (cond
-    (= Protos$MachineInfo$Mode/UP mode)       :machine-mode-up
-    (= Protos$MachineInfo$Mode/DRAINING mode) :machine-mode-draining
-    (= Protos$MachineInfo$Mode/DOWN mode)     :machine-mode-down))
+  (case mode
+    Protos$MachineInfo$Mode/UP       :machine-mode-up
+    Protos$MachineInfo$Mode/DRAINING :machine-mode-draining
+    Protos$MachineInfo$Mode/DOWN     :machine-mode-down))
 
 (defrecord MachineInfo [id mode unavailability]
   Serializable
@@ -332,8 +332,8 @@
 
 (defmethod pb->data Protos$FrameworkInfo$Capability$Type
   [^Protos$FrameworkInfo$Capability$Type type]
-  (cond
-    (= Protos$FrameworkInfo$Capability$Type/REVOCABLE_RESOURCES type)
+  (case
+    Protos$FrameworkInfo$Capability$Type/REVOCABLE_RESOURCES type
     :framework-capability-revocable-resource))
 
 (defrecord FrameworkInfo [user name id failover-timeout checkpoint role
@@ -552,12 +552,12 @@
 
 (defmethod pb->data Protos$Value$Type
   [^Protos$Value$Type type]
-  (cond
-    (= type Protos$Value$Type/SCALAR) :value-scalar
-    (= type Protos$Value$Type/RANGES) :value-ranges
-    (= type Protos$Value$Type/SET)    :value-set
-    (= type Protos$Value$Type/TEXT)   :value-text
-    :else type))
+  (case type
+    Protos$Value$Type/SCALAR :value-scalar
+    Protos$Value$Type/RANGES :value-ranges
+    Protos$Value$Type/SET    :value-set
+    Protos$Value$Type/TEXT   :value-text
+    type))
 
 (defmethod pb->data Protos$Value$Scalar
   [^Protos$Value$Scalar scalar]
@@ -1032,13 +1032,13 @@
 
 (defmethod pb->data Protos$Offer$Operation$Type
   [^Protos$Offer$Operation$Type type]
-  (cond
-    (= type Protos$Offer$Operation$Type/LAUNCH)    :operation-launch
-    (= type Protos$Offer$Operation$Type/RESERVE)   :operation-reserve
-    (= type Protos$Offer$Operation$Type/UNRESERVE) :operation-unreserve
-    (= type Protos$Offer$Operation$Type/CREATE)    :operation-create
-    (= type Protos$Offer$Operation$Type/DESTROY)   :operation-destroy
-    :else type))
+  (case type
+    Protos$Offer$Operation$Type/LAUNCH    :operation-launch
+    Protos$Offer$Operation$Type/RESERVE   :operation-reserve
+    Protos$Offer$Operation$Type/UNRESERVE :operation-unreserve
+    Protos$Offer$Operation$Type/CREATE    :operation-create
+    Protos$Offer$Operation$Type/DESTROY   :operation-destroy
+    type))
 
 (defrecord Operation [type tasks resources volumes]
   Serializable
@@ -1177,12 +1177,12 @@
 
 (defmethod pb->data Protos$DiscoveryInfo$Visibility
   [^Protos$DiscoveryInfo$Visibility vis]
-  (cond
-    (= Protos$DiscoveryInfo$Visibility/FRAMEWORK vis)
+  (case vis
+    Protos$DiscoveryInfo$Visibility/FRAMEWORK
     :discovery-visibility-framework
-    (= Protos$DiscoveryInfo$Visibility/CLUSTER vis)
+    Protos$DiscoveryInfo$Visibility/CLUSTER
     :discovery-visibility-cluster
-    (= Protos$DiscoveryInfo$Visibility/EXTERNAL vis)
+    Protos$DiscoveryInfo$Visibility/EXTERNAL
     :discovery-visibility-external))
 
 ;; TaskInfo
@@ -1225,65 +1225,64 @@
 
 (defmethod pb->data Protos$TaskState
   [^Protos$TaskState status]
-  (cond
-    (= status Protos$TaskState/TASK_STAGING)  :task-staging
-    (= status Protos$TaskState/TASK_STARTING) :task-starting
-    (= status Protos$TaskState/TASK_RUNNING)  :task-running
-    (= status Protos$TaskState/TASK_FINISHED) :task-finished
-    (= status Protos$TaskState/TASK_FAILED)   :task-failed
-    (= status Protos$TaskState/TASK_KILLED)   :task-killed
-    (= status Protos$TaskState/TASK_LOST)     :task-lost
-    (= status Protos$TaskState/TASK_ERROR)    :task-error
-    :else status))
+  (case status
+    Protos$TaskState/TASK_STAGING  :task-staging
+    Protos$TaskState/TASK_STARTING :task-starting
+    Protos$TaskState/TASK_RUNNING  :task-running
+    Protos$TaskState/TASK_FINISHED :task-finished
+    Protos$TaskState/TASK_FAILED   :task-failed
+    Protos$TaskState/TASK_KILLED   :task-killed
+    Protos$TaskState/TASK_LOST     :task-lost
+    Protos$TaskState/TASK_ERROR    :task-error
+    status))
 
 ;; TaskStatus
 ;; ==========
 
 (defmethod pb->data Protos$TaskStatus$Source
   [^Protos$TaskStatus$Source status]
-  (cond
-    (= status Protos$TaskStatus$Source/SOURCE_MASTER)   :source-master
-    (= status Protos$TaskStatus$Source/SOURCE_SLAVE)    :source-slave
-    (= status Protos$TaskStatus$Source/SOURCE_EXECUTOR) :source-executor
-    :else status))
+  (case status
+    Protos$TaskStatus$Source/SOURCE_MASTER   :source-master
+    Protos$TaskStatus$Source/SOURCE_SLAVE    :source-slave
+    Protos$TaskStatus$Source/SOURCE_EXECUTOR :source-executor
+    status))
 
 (defmethod pb->data Protos$TaskStatus$Reason
   [^Protos$TaskStatus$Reason status]
-
-  (cond
-    (= status Protos$TaskStatus$Reason/REASON_COMMAND_EXECUTOR_FAILED)
+  (case status
+    Protos$TaskStatus$Reason/REASON_COMMAND_EXECUTOR_FAILED
     :reason-command-executor-failed
-    (= status Protos$TaskStatus$Reason/REASON_EXECUTOR_TERMINATED)
+    Protos$TaskStatus$Reason/REASON_EXECUTOR_TERMINATED
     :reason-executor-terminated
-    (= status Protos$TaskStatus$Reason/REASON_EXECUTOR_UNREGISTERED)
+    Protos$TaskStatus$Reason/REASON_EXECUTOR_UNREGISTERED
     :reason-executor-unregistered
-    (= status Protos$TaskStatus$Reason/REASON_FRAMEWORK_REMOVED)
+    Protos$TaskStatus$Reason/REASON_FRAMEWORK_REMOVED
     :reason-framework-removed
-    (= status Protos$TaskStatus$Reason/REASON_GC_ERROR)
+    Protos$TaskStatus$Reason/REASON_GC_ERROR
     :reason-gc-error
-    (= status Protos$TaskStatus$Reason/REASON_INVALID_FRAMEWORKID)
+    Protos$TaskStatus$Reason/REASON_INVALID_FRAMEWORKID
     :reason-invalid-frameworkid
-    (= status Protos$TaskStatus$Reason/REASON_INVALID_OFFERS)
+    Protos$TaskStatus$Reason/REASON_INVALID_OFFERS
     :reason-invalid-offers
-    (= status Protos$TaskStatus$Reason/REASON_MASTER_DISCONNECTED)
+    Protos$TaskStatus$Reason/REASON_MASTER_DISCONNECTED
     :reason-master-disconnected
-    (= status Protos$TaskStatus$Reason/REASON_RECONCILIATION)
+    Protos$TaskStatus$Reason/REASON_RECONCILIATION
     :reason-reconciliation
-    (= status Protos$TaskStatus$Reason/REASON_SLAVE_DISCONNECTED)
+    Protos$TaskStatus$Reason/REASON_SLAVE_DISCONNECTED
     :reason-slave-disconnected
-    (= status Protos$TaskStatus$Reason/REASON_SLAVE_REMOVED)
+    Protos$TaskStatus$Reason/REASON_SLAVE_REMOVED
     :reason-slave-removed
-    (= status Protos$TaskStatus$Reason/REASON_SLAVE_RESTARTED)
+    Protos$TaskStatus$Reason/REASON_SLAVE_RESTARTED
     :reason-slave-restarted
-    (= status Protos$TaskStatus$Reason/REASON_SLAVE_UNKNOWN)
+    Protos$TaskStatus$Reason/REASON_SLAVE_UNKNOWN
     :reason-slave-unknown
-    (= status Protos$TaskStatus$Reason/REASON_TASK_INVALID)
+    Protos$TaskStatus$Reason/REASON_TASK_INVALID
     :reason-task-invalid
-    (= status Protos$TaskStatus$Reason/REASON_TASK_UNAUTHORIZED)
+    Protos$TaskStatus$Reason/REASON_TASK_UNAUTHORIZED
     :reason-task-unauthorized
-    (= status Protos$TaskStatus$Reason/REASON_TASK_UNKNOWN)
+    Protos$TaskStatus$Reason/REASON_TASK_UNKNOWN
     :reason-task-unknown
-    :else status))
+    status))
 
 (defrecord TaskStatus [task-id state message source reason
                        data slave-id executor-id timestamp
@@ -1453,10 +1452,10 @@
 
 (defmethod pb->data Protos$Volume$Mode
   [^Protos$Volume$Mode mode]
-  (cond
-    (= mode Protos$Volume$Mode/RW) :volume-rw
-    (= mode Protos$Volume$Mode/RO) :volume-ro
-    :else mode))
+  (case mode
+    Protos$Volume$Mode/RW :volume-rw
+    Protos$Volume$Mode/RO :volume-ro
+    mode))
 
 (defrecord Volume [container-path host-path mode]
   Serializable
@@ -1471,10 +1470,10 @@
 
 (defmethod pb->data Protos$ContainerInfo$Type
   [^Protos$ContainerInfo$Type type]
-  (cond
-    (= type Protos$ContainerInfo$Type/DOCKER) :container-type-docker
-    (= type Protos$ContainerInfo$Type/MESOS)  :conatiner-type-mesos
-    :else type))
+  (cond type
+    Protos$ContainerInfo$Type/DOCKER :container-type-docker
+    Protos$ContainerInfo$Type/MESOS  :conatiner-type-mesos
+    type))
 
 (defrecord PortMapping [host-port container-port protocol]
     Serializable
@@ -1494,14 +1493,14 @@
 
 (defmethod pb->data Protos$ContainerInfo$DockerInfo$Network
   [^Protos$ContainerInfo$DockerInfo$Network network]
-  (cond
-    (= network Protos$ContainerInfo$DockerInfo$Network/HOST)
+  (case network
+    Protos$ContainerInfo$DockerInfo$Network/HOST
     :docker-network-host
-    (= network Protos$ContainerInfo$DockerInfo$Network/BRIDGE)
+    Protos$ContainerInfo$DockerInfo$Network/BRIDGE
     :docker-network-bridge
-    (= network Protos$ContainerInfo$DockerInfo$Network/NONE)
+    Protos$ContainerInfo$DockerInfo$Network/NONE
     :docker-network-none
-    :else network))
+    network))
 
 (defrecord DockerInfo [image network port-mappings
                        privileged parameters]
@@ -1676,41 +1675,42 @@
   (data->pb
    (if (record? this)
      this
-     (cond
-       (= :FrameworkID map-type) (map->FrameworkID this)
-       (= :OfferID map-type) (map->OfferID this)
-       (= :SlaveID map-type) (map->SlaveID this)
-       (= :TaskID map-type)   (map->TaskID this)
-       (= :ExecutorID map-type) (map->ExecutorID this)
-       (= :ContainerID map-type) (map->ContainerID this)
-       (= :FrameworkInfo map-type) (map->FrameworkInfo this)
-       (= :HealthCheckHTTP map-type) (map->HealthCheckHTTP this)
-       (= :HealthCheck map-type) (map->HealthCheck this)
-       (= :URI map-type) (map->URI this)
-       (= :CommandInfo map-type) (map->CommandInfo this)
-       (= :ExecutorInfo map-type) (map->ExecutorInfo this)
-       (= :MasterInfo map-type)   (map->MasterInfo this)
-       (= :SlaveInfo map-type)    (map->SlaveInfo this)
-       (= :ValueRange map-type)   (map->ValueRange this)
-       (= :ValueRanges map-type)  (map->ValueRanges this)
-       (= :Value map-type)        (map->Value this)
-       (= :Attribute map-type)    (map->Attribute this)
-       (= :Resource map-type)     (map->Resource this)
-       (= :Request map-type)      (map->Request this)
-       (= :Offer map-type)                (map->Offer this)
-       (= :Operation map-type)            (map->Operation this)
-       (= :TaskInfo map-type)             (map->TaskInfo this)
-       (= :TaskStatus map-type)           (map->TaskStatus this)
-       (= :Filters map-type)              (map->Filters this)
-       (= :EnvironmentVariable map-type)  (map->EnvironmentVariable this)
-       (= :Environment map-type)          (map->Environment this)
-       (= :Parameter map-type)            (map->Parameter this)
-       (= :Parameters map-type)           (map->Parameter this)
-       (= :Credential map-type)           (map->Credential this)
-       (= :Credentials map-type)          (map->Credentials this)
-       (= :RateLimit map-type)            (map->RateLimit this)
-       (= :RateLimits map-type)           (map->RateLimits this)
-       (= :Volume map-type)               (map->Volume this)
-       (= :PortMapping map-type)          (map->PortMapping this)
-       (= :DockerInfo map-type)           (map->DockerInfo this)
-       (= :ContainerInfo map-type)        (map->ContainerInfo this)))))
+     (let [f (case map-type
+               :FrameworkID         map->FrameworkID
+               :OfferID             map->OfferID
+               :SlaveID             map->SlaveID
+               :TaskID              map->TaskID
+               :ExecutorID          map->ExecutorID
+               :ContainerID         map->ContainerID
+               :FrameworkInfo       map->FrameworkInfo
+               :HealthCheckHTTP     map->HealthCheckHTTP
+               :HealthCheck         map->HealthCheck
+               :URI                 map->URI
+               :CommandInfo         map->CommandInfo
+               :ExecutorInfo        map->ExecutorInfo
+               :MasterInfo          map->MasterInfo
+               :SlaveInfo           map->SlaveInfo
+               :ValueRange          map->ValueRange
+               :ValueRanges         map->ValueRanges
+               :Value               map->Value
+               :Attribute           map->Attribute
+               :Resource            map->Resource
+               :Request             map->Request
+               :Offer               map->Offer
+               :Operation           map->Operation
+               :TaskInfo            map->TaskInfo
+               :TaskStatus          map->TaskStatus
+               :Filters             map->Filters
+               :EnvironmentVariable map->EnvironmentVariable
+               :Environment         map->Environment
+               :Parameter           map->Parameter
+               :Parameters          map->Parameter
+               :Credential          map->Credential
+               :Credentials         map->Credentials
+               :RateLimit           map->RateLimit
+               :RateLimits          map->RateLimits
+               :Volume              map->Volume
+               :PortMapping         map->PortMapping
+               :DockerInfo          map->DockerInfo
+               :ContainerInfo       map->ContainerInfo)]
+       (f this)))))

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1,5 +1,6 @@
 (ns mesomatic.types
   "Utility functions to convert to and from mesos types."
+  (:require [mesomatic.utils :refer [case-enum]])
   (:import org.apache.mesos.Protos$Status
            org.apache.mesos.Protos$FrameworkID
            org.apache.mesos.Protos$OfferID
@@ -97,15 +98,14 @@
 ;; will can be converted back with the extend-protocol
 ;; trick later on.
 
-(def ^:private Protos$Status-dispatch-map
-  {Protos$Status/DRIVER_RUNNING     :driver-running
-   Protos$Status/DRIVER_NOT_STARTED :driver-not-started
-   Protos$Status/DRIVER_ABORTED     :driver-aborted
-   Protos$Status/DRIVER_STOPPED     :driver-stopped})
-
 (defmethod pb->data Protos$Status
   [^Protos$Status status]
-  (get Protos$Status-dispatch-map status status))
+  (case-enum status
+    Protos$Status/DRIVER_RUNNING     :driver-running
+    Protos$Status/DRIVER_NOT_STARTED :driver-not-started
+    Protos$Status/DRIVER_ABORTED     :driver-aborted
+    Protos$Status/DRIVER_STOPPED     :driver-stopped
+    status))
 
 ;; FrameworkID
 ;; ===========
@@ -294,14 +294,12 @@
 ;; MachineInfo
 ;; ===========
 
-(def ^:private Protos$MachineInfo$Mode-dispatch-map
-  {Protos$MachineInfo$Mode/UP       :machine-mode-up
-   Protos$MachineInfo$Mode/DRAINING :machine-mode-draining
-   Protos$MachineInfo$Mode/DOWN     :machine-mode-down})
-
 (defmethod pb->data Protos$MachineInfo$Mode
   [^Protos$MachineInfo$Mode mode]
-  (get Protos$MachineInfo$Mode-dispatch-map mode))
+  (case-enum mode
+    Protos$MachineInfo$Mode/UP       :machine-mode-up
+    Protos$MachineInfo$Mode/DRAINING :machine-mode-draining
+    Protos$MachineInfo$Mode/DOWN     :machine-mode-down))
 
 (defrecord MachineInfo [id mode unavailability]
   Serializable
@@ -335,8 +333,9 @@
 
 (defmethod pb->data Protos$FrameworkInfo$Capability$Type
   [^Protos$FrameworkInfo$Capability$Type type]
-  (cond (= type Protos$FrameworkInfo$Capability$Type/REVOCABLE_RESOURCES)
-        :framework-capability-revocable-resource))
+  (case-enum type
+    Protos$FrameworkInfo$Capability$Type/REVOCABLE_RESOURCES
+    :framework-capability-revocable-resource))
 
 (defrecord FrameworkInfo [user name id failover-timeout checkpoint role
                           hostname principal webui-url capabilities labels]
@@ -552,15 +551,14 @@
 ;; Value
 ;; =====
 
-(def ^:private Protos$Value$Type-dispatch-map
-  {Protos$Value$Type/SCALAR :value-scalar
-   Protos$Value$Type/RANGES :value-ranges
-   Protos$Value$Type/SET    :value-set
-   Protos$Value$Type/TEXT   :value-text})
-
 (defmethod pb->data Protos$Value$Type
   [^Protos$Value$Type type]
-  (get Protos$Value$Type-dispatch-map type type))
+  (case-enum type
+    Protos$Value$Type/SCALAR :value-scalar
+    Protos$Value$Type/RANGES :value-ranges
+    Protos$Value$Type/SET    :value-set
+    Protos$Value$Type/TEXT   :value-text
+    type))
 
 (defmethod pb->data Protos$Value$Scalar
   [^Protos$Value$Scalar scalar]
@@ -1033,16 +1031,15 @@
 ;; Operation
 ;; =========
 
-(def ^:private Protos$Offer$Operation$Type-dispatch-map
-  {Protos$Offer$Operation$Type/LAUNCH    :operation-launch
-   Protos$Offer$Operation$Type/RESERVE   :operation-reserve
-   Protos$Offer$Operation$Type/UNRESERVE :operation-unreserve
-   Protos$Offer$Operation$Type/CREATE    :operation-create
-   Protos$Offer$Operation$Type/DESTROY   :operation-destroy})
-
 (defmethod pb->data Protos$Offer$Operation$Type
   [^Protos$Offer$Operation$Type type]
-  (get Protos$Offer$Operation$Type-dispatch-map type type))
+  (case-enum type
+    Protos$Offer$Operation$Type/LAUNCH    :operation-launch
+    Protos$Offer$Operation$Type/RESERVE   :operation-reserve
+    Protos$Offer$Operation$Type/UNRESERVE :operation-unreserve
+    Protos$Offer$Operation$Type/CREATE    :operation-create
+    Protos$Offer$Operation$Type/DESTROY   :operation-destroy
+    type))
 
 (defrecord Operation [type tasks resources volumes]
   Serializable
@@ -1179,14 +1176,15 @@
                   (when-let [ports (.getPorts di)] (pb->data ports))
                   (when-let [labels (.getLabels di)] (pb->data labels))))
 
-(def ^:private Protos$DiscoveryInfo$Visibility-dispatch-map
-  {Protos$DiscoveryInfo$Visibility/FRAMEWORK :discovery-visibility-framework
-   Protos$DiscoveryInfo$Visibility/CLUSTER   :discovery-visibility-cluster
-   Protos$DiscoveryInfo$Visibility/EXTERNAL  :discovery-visibility-external})
-
 (defmethod pb->data Protos$DiscoveryInfo$Visibility
   [^Protos$DiscoveryInfo$Visibility vis]
-  (get Protos$DiscoveryInfo$Visibility-dispatch-map vis))
+  (case-enum vis
+    Protos$DiscoveryInfo$Visibility/FRAMEWORK
+    :discovery-visibility-framework
+    Protos$DiscoveryInfo$Visibility/CLUSTER
+    :discovery-visibility-cluster
+    Protos$DiscoveryInfo$Visibility/EXTERNAL
+    :discovery-visibility-external))
 
 ;; TaskInfo
 ;; ========
@@ -1226,69 +1224,66 @@
 ;; TaskState
 ;; =========
 
-(def ^:private Protos$TaskState-dispatch-map
-  {Protos$TaskState/TASK_STAGING  :task-staging
-   Protos$TaskState/TASK_STARTING :task-starting
-   Protos$TaskState/TASK_RUNNING  :task-running
-   Protos$TaskState/TASK_FINISHED :task-finished
-   Protos$TaskState/TASK_FAILED   :task-failed
-   Protos$TaskState/TASK_KILLED   :task-killed
-   Protos$TaskState/TASK_LOST     :task-lost
-   Protos$TaskState/TASK_ERROR    :task-error})
-
 (defmethod pb->data Protos$TaskState
   [^Protos$TaskState status]
-  (get Protos$TaskState-dispatch-map status status))
+  (case-enum status
+    Protos$TaskState/TASK_STAGING  :task-staging
+    Protos$TaskState/TASK_STARTING :task-starting
+    Protos$TaskState/TASK_RUNNING  :task-running
+    Protos$TaskState/TASK_FINISHED :task-finished
+    Protos$TaskState/TASK_FAILED   :task-failed
+    Protos$TaskState/TASK_KILLED   :task-killed
+    Protos$TaskState/TASK_LOST     :task-lost
+    Protos$TaskState/TASK_ERROR    :task-error
+    status))
 
 ;; TaskStatus
 ;; ==========
 
-(def ^:private Protos$TaskStatus$Source-dispatch-map
-  {Protos$TaskStatus$Source/SOURCE_MASTER   :source-master
-   Protos$TaskStatus$Source/SOURCE_SLAVE    :source-slave
-   Protos$TaskStatus$Source/SOURCE_EXECUTOR :source-executor})
-
 (defmethod pb->data Protos$TaskStatus$Source
   [^Protos$TaskStatus$Source status]
-  (get Protos$TaskStatus$Source-dispatch-map status status))
-
-(def ^:private Protos$TaskStatus$Reason-dispatch-map
-  {Protos$TaskStatus$Reason/REASON_COMMAND_EXECUTOR_FAILED
-   :reason-command-executor-failed
-   Protos$TaskStatus$Reason/REASON_EXECUTOR_TERMINATED
-   :reason-executor-terminated
-   Protos$TaskStatus$Reason/REASON_EXECUTOR_UNREGISTERED
-   :reason-executor-unregistered
-   Protos$TaskStatus$Reason/REASON_FRAMEWORK_REMOVED
-   :reason-framework-removed
-   Protos$TaskStatus$Reason/REASON_GC_ERROR
-   :reason-gc-error
-   Protos$TaskStatus$Reason/REASON_INVALID_FRAMEWORKID
-   :reason-invalid-frameworkid
-   Protos$TaskStatus$Reason/REASON_INVALID_OFFERS
-   :reason-invalid-offers
-   Protos$TaskStatus$Reason/REASON_MASTER_DISCONNECTED
-   :reason-master-disconnected
-   Protos$TaskStatus$Reason/REASON_RECONCILIATION
-   :reason-reconciliation
-   Protos$TaskStatus$Reason/REASON_SLAVE_DISCONNECTED
-   :reason-slave-disconnected
-   Protos$TaskStatus$Reason/REASON_SLAVE_REMOVED
-   :reason-slave-removed
-   Protos$TaskStatus$Reason/REASON_SLAVE_RESTARTED
-   :reason-slave-restarted
-   Protos$TaskStatus$Reason/REASON_SLAVE_UNKNOWN
-   :reason-slave-unknown
-   Protos$TaskStatus$Reason/REASON_TASK_INVALID
-   :reason-task-invalid
-   Protos$TaskStatus$Reason/REASON_TASK_UNAUTHORIZED
-   :reason-task-unauthorized
-   Protos$TaskStatus$Reason/REASON_TASK_UNKNOWN
-   :reason-task-unknown})
+  (case-enum status
+    Protos$TaskStatus$Source/SOURCE_MASTER   :source-master
+    Protos$TaskStatus$Source/SOURCE_SLAVE    :source-slave
+    Protos$TaskStatus$Source/SOURCE_EXECUTOR :source-executor
+    status))
 
 (defmethod pb->data Protos$TaskStatus$Reason
   [^Protos$TaskStatus$Reason status]
-  (get Protos$TaskStatus$Reason-dispatch-map status status))
+  (case-enum status
+    Protos$TaskStatus$Reason/REASON_COMMAND_EXECUTOR_FAILED
+    :reason-command-executor-failed
+    Protos$TaskStatus$Reason/REASON_EXECUTOR_TERMINATED
+    :reason-executor-terminated
+    Protos$TaskStatus$Reason/REASON_EXECUTOR_UNREGISTERED
+    :reason-executor-unregistered
+    Protos$TaskStatus$Reason/REASON_FRAMEWORK_REMOVED
+    :reason-framework-removed
+    Protos$TaskStatus$Reason/REASON_GC_ERROR
+    :reason-gc-error
+    Protos$TaskStatus$Reason/REASON_INVALID_FRAMEWORKID
+    :reason-invalid-frameworkid
+    Protos$TaskStatus$Reason/REASON_INVALID_OFFERS
+    :reason-invalid-offers
+    Protos$TaskStatus$Reason/REASON_MASTER_DISCONNECTED
+    :reason-master-disconnected
+    Protos$TaskStatus$Reason/REASON_RECONCILIATION
+    :reason-reconciliation
+    Protos$TaskStatus$Reason/REASON_SLAVE_DISCONNECTED
+    :reason-slave-disconnected
+    Protos$TaskStatus$Reason/REASON_SLAVE_REMOVED
+    :reason-slave-removed
+    Protos$TaskStatus$Reason/REASON_SLAVE_RESTARTED
+    :reason-slave-restarted
+    Protos$TaskStatus$Reason/REASON_SLAVE_UNKNOWN
+    :reason-slave-unknown
+    Protos$TaskStatus$Reason/REASON_TASK_INVALID
+    :reason-task-invalid
+    Protos$TaskStatus$Reason/REASON_TASK_UNAUTHORIZED
+    :reason-task-unauthorized
+    Protos$TaskStatus$Reason/REASON_TASK_UNKNOWN
+    :reason-task-unknown
+    status))
 
 (defrecord TaskStatus [task-id state message source reason
                        data slave-id executor-id timestamp
@@ -1456,13 +1451,12 @@
 ;; Volume
 ;; ======
 
-(def ^:private Protos$Volume$Mode-dispatch-map
-  {Protos$Volume$Mode/RW :volume-rw
-   Protos$Volume$Mode/RO :volume-ro})
-
 (defmethod pb->data Protos$Volume$Mode
   [^Protos$Volume$Mode mode]
-  (get Protos$Volume$Mode-dispatch-map mode mode))
+  (case-enum mode
+    Protos$Volume$Mode/RW :volume-rw
+    Protos$Volume$Mode/RO :volume-ro
+    mode))
 
 (defrecord Volume [container-path host-path mode]
   Serializable
@@ -1475,13 +1469,12 @@
 ;; ContainerInfo
 ;; =============
 
-(def ^:private Protos$ContainerInfo$Type-dispatch-map
-  {Protos$ContainerInfo$Type/DOCKER :container-type-docker
-   Protos$ContainerInfo$Type/MESOS  :conatiner-type-mesos})
-
 (defmethod pb->data Protos$ContainerInfo$Type
   [^Protos$ContainerInfo$Type type]
-  (get Protos$ContainerInfo$Type-dispatch-map type type))
+  (cond type
+    Protos$ContainerInfo$Type/DOCKER :container-type-docker
+    Protos$ContainerInfo$Type/MESOS  :conatiner-type-mesos
+    type))
 
 (defrecord PortMapping [host-port container-port protocol]
     Serializable
@@ -1499,17 +1492,16 @@
    (.getContainerPort pm)
    (.getProtocol pm)))
 
-(def ^:private Protos$ContainerInfo$DockerInfo$Network-dispatch-map
-  {Protos$ContainerInfo$DockerInfo$Network/HOST
-   :docker-network-host
-   Protos$ContainerInfo$DockerInfo$Network/BRIDGE
-   :docker-network-bridge
-   Protos$ContainerInfo$DockerInfo$Network/NONE
-   :docker-network-none})
-
 (defmethod pb->data Protos$ContainerInfo$DockerInfo$Network
   [^Protos$ContainerInfo$DockerInfo$Network network]
-  (get Protos$ContainerInfo$DockerInfo$Network-dispatch-map network network))
+  (case-enum network
+    Protos$ContainerInfo$DockerInfo$Network/HOST
+    :docker-network-host
+    Protos$ContainerInfo$DockerInfo$Network/BRIDGE
+    :docker-network-bridge
+    Protos$ContainerInfo$DockerInfo$Network/NONE
+    :docker-network-none
+    network))
 
 (defrecord DockerInfo [image network port-mappings
                        privileged parameters]

--- a/src/mesomatic/utils.clj
+++ b/src/mesomatic/utils.clj
@@ -1,0 +1,14 @@
+(ns mesomatic.utils
+  "Some convenience/utility functions used in the rest of Mesomatic.")
+
+(defmacro case-enum
+  "Like `case`, but explicitly dispatch on Java enum ordinals."
+  [e & clauses]
+  (letfn [(enum-ordinal [e] `(let [^Enum e# ~e] (.ordinal e#)))]
+    `(case ~(enum-ordinal e)
+       ~@(concat
+          (mapcat (fn [[test result]]
+                    [(eval (enum-ordinal test)) result])
+                  (partition 2 clauses))
+          (when (odd? (count clauses))
+            (list (last clauses)))))))


### PR DESCRIPTION
- Moving from `cond` to `case` when possible turns a worst-case O(N)
  (where N is the number of possible objects to which the test constant
  might be equal) check into a worst-case O(1) check.
- While it is not clear whether the affected code paths are
  bottlenecks, performance will nevertheless be improved in those code
  paths.
- All tests continue to pass
