### PR TITLE
Add FrameworkCapability factory

### DIFF
--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1726,6 +1726,7 @@
      this
      (cond
        (= :FrameworkID map-type) (map->FrameworkID this)
+       (= :FrameworkCapability map-type) (map->FrameworkCapability this)
        (= :OfferID map-type) (map->OfferID this)
        (= :SlaveID map-type) (map->SlaveID this)
        (= :TaskID map-type)   (map->TaskID this)


### PR DESCRIPTION
On further testing, I discovered that this extra line was missing. I now have successfully tested getting a Mesomatic framework to connect to a cluster with the GPU_CAPABILITY.
