### PR TITLE
Fix Credential use of principal and build VolumeBuilder

### DIFF
--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1412,7 +1412,7 @@
   Serializable
   (data->pb [this]
     (-> (Protos$Credential/newBuilder)
-        (.setPrincipal (str key))
+        (.setPrincipal (str principal))
         (cond-> secret (.setSecret (str secret)))
         (.build))))
 

--- a/src/mesomatic/types.clj
+++ b/src/mesomatic/types.clj
@@ -1487,7 +1487,8 @@
     (-> (Protos$Volume/newBuilder)
         (.setContainerPath (str container-path))
         (.setMode (data->pb mode))
-        (cond-> host-path (.setHostPath (str host-path))))))
+        (cond-> host-path (.setHostPath (str host-path)))
+        (.build))))
 
 ;; ContainerInfo
 ;; =============


### PR DESCRIPTION
Looks like a bug from an earlier version that was using key.
